### PR TITLE
🎨 Palette: Add focus-visible styles for keyboard navigation

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-03-10 - Explicit focus-visible styles missing for interactive elements
+**Learning:** Found that keyboard navigation was lacking clear focus indicators across the application for elements like links, buttons, and form inputs.
+**Action:** Always ensure that `a:focus-visible`, `.button:focus-visible`, `input:focus-visible`, and `textarea:focus-visible` are defined in `global.css` or equivalent to provide clear keyboard accessibility cues.

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -169,3 +169,16 @@ textarea {
 		padding: 2em 1em 3em;
 	}
 }
+/* Accessibility enhancements */
+a:focus-visible,
+.button:focus-visible {
+	outline: 3px solid var(--primary);
+	outline-offset: 3px;
+	border-radius: 4px;
+}
+
+input:focus-visible,
+textarea:focus-visible {
+	outline: 2px solid var(--primary);
+	outline-offset: 1px;
+}


### PR DESCRIPTION
💡 What: Added `:focus-visible` styles to interactive elements (`a`, `.button`, `input`, `textarea`) in `global.css`.

🎯 Why: To improve accessibility for users who rely on keyboard navigation. Previously, elements lacked explicit focus indicators, making it hard to track where the focus was on the page.

♿ Accessibility: Ensures WCAG compliance by providing visible focus indicators without disrupting the visual experience for mouse or touch users.

📝 Also added a learning entry to `.Jules/palette.md` for future reference.

---
*PR created automatically by Jules for task [12897221333479377436](https://jules.google.com/task/12897221333479377436) started by @Lennart01*